### PR TITLE
:recycle: Refactor to make "pill" width consistent on right side

### DIFF
--- a/src/components/CurrentHourly.js
+++ b/src/components/CurrentHourly.js
@@ -35,7 +35,7 @@ export const CurrentHourly = ({ data }) => {
               <div className="summary">{hourData && data && formatSummary(hourData, data.hourly.data, index, startIndex)}</div>
               <div className="condition">
                 <span className={hourlyConditionToShow === 'uvIndex' ? getUvIndexClasses(hourData[hourlyConditionToShow]) : 'pill'}>
-                  {formatCondition(hourData[hourlyConditionToShow], hourlyConditionToShow).trim()}
+                  {formatCondition(hourData[hourlyConditionToShow], hourlyConditionToShow)}
                 </span>
               </div>
             </li>

--- a/src/components/CurrentHourly.scss
+++ b/src/components/CurrentHourly.scss
@@ -30,7 +30,6 @@
     @apply text-center;
     @apply border-2;
     @apply focus:outline-none;
-
   }
 
   .pill {
@@ -98,13 +97,6 @@
       @apply italic;
     }
 
-    // .spacer {
-    //   @apply flex-auto;
-    //   @apply inline-block;
-    //   @apply overflow-hidden;
-    //   @apply align-top;
-    // }
-
     .condition {
       @apply inline-block;
       @apply align-top;
@@ -121,6 +113,10 @@
         @apply bg-white;
         @apply rounded-full;
         @apply w-12;
+        @apply text-center;
+        @apply inline-block;
+        @apply leading-6;
+        @apply w-14;
 
         &.orange {
           @apply bg-orange-500;

--- a/src/modules/helpers.js
+++ b/src/modules/helpers.js
@@ -138,9 +138,9 @@ export const getWeatherIcon = (icon) => {
   return iconMap[icon];
 };
 
-const formatTemp = (temp) => `${Math.round(temp).toString().padStart(2, String.fromCharCode(160))}${String.fromCharCode(176)}`;
-const formatPercent = (num) => `${Math.round(num * 100).toString().padStart(2, String.fromCharCode(160))}%`;
-const formatNum = (num) => `${Math.round(num).toString().padStart(2, String.fromCharCode(160))}`;
+const formatTemp = (temp) => `${Math.round(temp).toString()}${String.fromCharCode(176)}`;
+const formatPercent = (num) => `${Math.round(num * 100).toString()}%`;
+const formatNum = (num) => `${Math.round(num).toString()}`;
 
 export const formatCondition = (value, condition) => {
   switch (condition) {


### PR DESCRIPTION
- [x] Removes padStart in formatting functions
- [x] Adds styles to "pill" to make fixed width and center text
- [x] Removes extraneous .trim()