### PR TITLE
chore(deps-dev): ⬆️ bump eslint-config-stylelint from 17.0.0 to 17.1.…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "eslint": "8.28.0",
         "eslint-config-airbnb": "19.0.4",
         "eslint-config-prettier": "8.5.0",
-        "eslint-config-stylelint": "17.0.0",
+        "eslint-config-stylelint": "17.1.0",
         "eslint-plugin-compat": "4.0.2",
         "eslint-plugin-html": "7.1.0",
         "eslint-plugin-import": "2.26.0",
@@ -5790,15 +5790,15 @@
       }
     },
     "node_modules/eslint-config-stylelint": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-17.0.0.tgz",
-      "integrity": "sha512-9HrWIUYw24m/Tom0X65e+ovPSnopXEY1lJYdcLrRbozr9Qu2qWr9+TN6dGppMuNitjm8/hMDfy+0rUP6oSyKFQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-17.1.0.tgz",
+      "integrity": "sha512-W4wVdtIUdgjNpIAdWtFtsxuxCu7uSe+2WuTerH923UW800+B0FbO+9uk0ZFFvu9+MYdLyQ+RYU8GLjl9ZnCm8g==",
       "dev": true,
       "dependencies": {
         "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-jest": "^27.0.4",
+        "eslint-plugin-jest": "^27.1.6",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-regexp": "^1.9.0"
+        "eslint-plugin-regexp": "^1.11.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint": "8.28.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "8.5.0",
-    "eslint-config-stylelint": "17.0.0",
+    "eslint-config-stylelint": "17.1.0",
     "eslint-plugin-compat": "4.0.2",
     "eslint-plugin-html": "7.1.0",
     "eslint-plugin-import": "2.26.0",


### PR DESCRIPTION
…0 (#165)

Bumps [eslint-config-stylelint](https://github.com/stylelint/eslint-config-stylelint) from 17.0.0 to 17.1.0.
- [Release notes](https://github.com/stylelint/eslint-config-stylelint/releases)
- [Changelog](https://github.com/stylelint/eslint-config-stylelint/blob/main/CHANGELOG.md)
- [Commits](https://github.com/stylelint/eslint-config-stylelint/compare/17.0.0...17.1.0)

---
updated-dependencies:
- dependency-name: eslint-config-stylelint dependency-type: direct:development update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>